### PR TITLE
Fix syntax error by removing merge markers and using config for server

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,23 +72,6 @@ func main() {
 		log.Fatal(err)
 	}
 	log.Printf("listening on %s", addr)
-=======
-	"strconv"
-)
-
-var (
-	listenAddr = flag.String("addr", ":1080", "listen address")
-	username   = flag.String("user", "user", "username")
-	password   = flag.String("pass", "pass", "password")
-)
-
-func main() {
-	flag.Parse()
-	ln, err := net.Listen("tcp", *listenAddr)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("listening on %s", *listenAddr)
 	for {
 		c, err := ln.Accept()
 		if err != nil {


### PR DESCRIPTION
## Summary
- remove leftover merge markers that caused build failure
- load bind address and credentials from config file when starting server

## Testing
- `go build`
- `go test`


------
https://chatgpt.com/codex/tasks/task_e_689c6d04f8988324ac11422ee7c700c2