### PR TITLE
Add configurable logging level and format

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,3 +2,5 @@ bind: "0.0.0.0"
 port: 1080
 username: "user"
 password: "pass"
+log_level: "info"
+log_format: "text"


### PR DESCRIPTION
## Summary
- allow configuring log level and format via `log_level` and `log_format`
- support structured JSON logs in addition to text output

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c9a3990848324bebf9f88a8fbf863