### PR TITLE
Allow configuring proxy check intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ proxy chaining.
 
 Configuration is stored in a YAML file with two sections:
 
-* **general** – listener and logging settings
+* **general** – listener, logging, and health check settings
 * **chains** – list of user credentials and their proxy chains
 
 Each entry in `chains` defines the username/password a client must supply
@@ -28,6 +28,7 @@ general:
   port: 1080
   log_level: "info"
   log_format: "text"
+  health_check_interval: 30s
 
 chains:
   - username: "user"
@@ -51,6 +52,9 @@ chains:
             host: "proxy3.example"
             port: 1080
 ```
+
+`health_check_interval` controls how often upstream proxies are probed to
+determine their availability. If omitted, it defaults to `30s`.
 
 ## Usage
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ general:
   port: 1080
   log_level: "info"
   log_format: "text"
+  health_check_interval: 30s
 
 chains:
   - username: "user"

--- a/main.go
+++ b/main.go
@@ -46,13 +46,14 @@ var (
 	debugLog logger
 )
 
-const healthCheckInterval = 30 * time.Second
+const defaultHealthCheckInterval = 30 * time.Second
 
 type General struct {
-	Bind      string `yaml:"bind"`
-	Port      int    `yaml:"port"`
-	LogLevel  string `yaml:"log_level"`
-	LogFormat string `yaml:"log_format"`
+	Bind                string        `yaml:"bind"`
+	Port                int           `yaml:"port"`
+	LogLevel            string        `yaml:"log_level"`
+	LogFormat           string        `yaml:"log_format"`
+	HealthCheckInterval time.Duration `yaml:"health_check_interval"`
 }
 
 type Proxy struct {
@@ -151,6 +152,9 @@ func loadConfig(path string) (Config, error) {
 	if cfg.General.LogFormat == "" {
 		cfg.General.LogFormat = "text"
 	}
+	if cfg.General.HealthCheckInterval == 0 {
+		cfg.General.HealthCheckInterval = defaultHealthCheckInterval
+	}
 	return cfg, nil
 }
 
@@ -221,7 +225,7 @@ func main() {
 	for _, uc := range cfg.Chains {
 		userChains[uc.Username] = uc
 	}
-	startHealthChecks(&cfg, healthCheckInterval)
+	startHealthChecks(&cfg, cfg.General.HealthCheckInterval)
 	for {
 		c, err := ln.Accept()
 		if err != nil {


### PR DESCRIPTION
## Summary
- make proxy health check interval configurable via `health_check_interval`
- document proxy check interval setting

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d4a40c11883249316e506a0f9f6d2