### PR TITLE
Refactor chain dialing and add cleanup cache

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ general:
   log_level: "info"
   log_format: "text"
   health_check_interval: 30s
+  chain_cleanup_interval: 10m
 
 chains:
   - username: "user"


### PR DESCRIPTION
## Summary
- Rework proxy chain dialing to build and test combinations lazily
- Cache successful proxy chains and purge unused entries periodically
- Allow configuring chain cache cleanup interval

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d9ebc43b88324bc2ea724b9f09c8e