### PR TITLE
Validate configuration before use

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidateConfig(t *testing.T) {
+	validGen := General{
+		Bind:                  "127.0.0.1",
+		Port:                  1080,
+		HealthCheckInterval:   time.Second,
+		ChainCleanupInterval:  time.Second,
+		HealthCheckTimeout:    time.Second,
+		HealthCheckConcurrent: 1,
+	}
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "invalid general port",
+			cfg: Config{General: General{
+				Bind:                  "0.0.0.0",
+				Port:                  70000,
+				HealthCheckInterval:   time.Second,
+				ChainCleanupInterval:  time.Second,
+				HealthCheckTimeout:    time.Second,
+				HealthCheckConcurrent: 1,
+			}},
+		},
+		{
+			name: "invalid hop port",
+			cfg: Config{
+				General: validGen,
+				Chains: []UserChain{
+					{
+						Chain: []*Hop{
+							{Host: "example.com", Port: 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid strategy",
+			cfg: Config{
+				General: validGen,
+				Chains: []UserChain{
+					{
+						Chain: []*Hop{
+							{
+								Strategy: "bogus",
+								Proxies:  []*Proxy{{Host: "proxy.example", Port: 1080}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateConfig(&tt.cfg); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestLoadConfigInvalid(t *testing.T) {
+	if _, err := loadConfig("testdata/invalid_config.yaml"); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/testdata/invalid_config.yaml
+++ b/testdata/invalid_config.yaml
@@ -1,0 +1,17 @@
+general:
+  bind: "0.0.0.0"
+  port: 1080
+  health_check_interval: 30s
+  chain_cleanup_interval: 10m
+  health_check_timeout: 5s
+  health_check_concurrency: 10
+
+chains:
+  - username: "user"
+    password: "pass"
+    chain:
+      - strategy: "invalid"
+        proxies:
+          - name: "badproxy"
+            host: "proxy1.example"
+            port: 70000


### PR DESCRIPTION
## Summary
- add a `validateConfig` function to verify required fields, ports, durations, strategies and proxy definitions
- call validation from `loadConfig` so invalid configs return an error
- include tests and an example invalid configuration

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ef68840988324b56d7cd6bfd75e86