### PR TITLE
Add priority-based load balancing strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Configuration is stored in a YAML file with two sections:
 Each entry in `chains` defines the username/password a client must supply
 and an ordered sequence of hops. A hop may specify a single upstream
 SOCKS5 proxy directly or provide multiple proxies with a load-balancing
-strategy. When multiple proxies are listed, they are tried according to
-the selected strategy until a connection succeeds. Supported strategies
-are `rr` (round-robin) and `random`. Hops are traversed in the order they
-are listed. If `chains` is empty, authentication is not required and
-connections are made directly.
+  strategy. When multiple proxies are listed, they are tried according to
+  the selected strategy until a connection succeeds. Supported strategies
+  are `rr` (round-robin), `random`, and `priority` (highest priority first
+  with round-robin on ties). Hops are traversed in the order they
+  are listed. If `chains` is empty, authentication is not required and
+  connections are made directly.
 
 Example configuration:
 
@@ -95,7 +96,7 @@ Additional hop parameters:
 
 | Field | Description | Values | Default |
 | ----- | ----------- | ------ | ------- |
-| `strategy` | Order in which proxies from `proxies` are attempted. | `rr` for round‑robin, `random` for random selection. | `rr` |
+| `strategy` | Order in which proxies from `proxies` are attempted. | `rr` for round‑robin, `random` for random selection, `priority` to use proxy priorities. | `rr` |
 
 #### Proxy fields
 
@@ -108,6 +109,7 @@ Proxy definitions used either directly in a hop or within a `proxies` list inclu
 | `password` | Password for upstream proxy authentication. |
 | `host` | Hostname or IP of the upstream proxy. |
 | `port` | TCP port of the upstream proxy. |
+| `priority` | Optional integer; higher values are tried first. Proxies with the same priority use round‑robin. |
 
 The server performs health checks on all defined proxies at the interval specified by `health_check_interval`. When a proxy fails a check it is temporarily excluded from rotation until it becomes reachable again.
 

--- a/chain_priority_test.go
+++ b/chain_priority_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestPriorityStrategy(t *testing.T) {
+	p1 := &Proxy{Name: "p1", Host: "h1", Port: 1, Priority: 1}
+	p2 := &Proxy{Name: "p2", Host: "h2", Port: 2, Priority: 1}
+	p3 := &Proxy{Name: "p3", Host: "h3", Port: 3, Priority: 2}
+	cfg := Config{Chains: []UserChain{{Chain: []*Hop{{Strategy: "priority", Proxies: []*Proxy{p1, p2, p3}}}}}}
+	initProxies(&cfg)
+	hop := cfg.Chains[0].Chain[0]
+	res1 := hop.orderedProxies()
+	if len(res1) != 3 || res1[0] != p3 || res1[1] != p1 || res1[2] != p2 {
+		t.Fatalf("unexpected order1: %v", res1)
+	}
+	res2 := hop.orderedProxies()
+	if len(res2) != 3 || res2[0] != p3 || res2[1] != p2 || res2[2] != p1 {
+		t.Fatalf("unexpected order2: %v", res2)
+	}
+}


### PR DESCRIPTION
## Summary
- add `priority` load-balancing strategy choosing highest-priority proxies with round-robin ties
- document new strategy and proxy `priority` field
- cover priority balancing with unit test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a025cf1be483249a229cde96604365