### PR TITLE
Add bidirectional proxy helper

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io"
+	"net"
+)
+
+// proxy copies data between a and b. When one side returns an error or EOF,
+// the opposite connection is closed to ensure both sides terminate.
+func proxy(a, b net.Conn) {
+	done := make(chan struct{}, 2)
+
+	go func() {
+		_, _ = io.Copy(a, b)
+		a.Close()
+		done <- struct{}{}
+	}()
+
+	go func() {
+		_, _ = io.Copy(b, a)
+		b.Close()
+		done <- struct{}{}
+	}()
+
+	<-done
+	<-done
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"io"
+	"net"
+	"testing"
+)
+
+func TestProxyClosesOnClientClose(t *testing.T) {
+	c1, c2 := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		proxy(c1, c2)
+		close(done)
+	}()
+
+	msg := []byte("hello")
+	go func() {
+		c1.Write(msg)
+		c1.Close()
+	}()
+
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(c2, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != string(msg) {
+		t.Fatalf("unexpected message: %q", buf)
+	}
+
+	<-done
+
+	if _, err := c2.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expected c2 to be closed")
+	}
+}
+
+func TestProxyClosesOnRemoteClose(t *testing.T) {
+	c1, c2 := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		proxy(c1, c2)
+		close(done)
+	}()
+
+	msg := []byte("world")
+	go func() {
+		c2.Write(msg)
+		c2.Close()
+	}()
+
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(c1, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != string(msg) {
+		t.Fatalf("unexpected message: %q", buf)
+	}
+
+	<-done
+
+	if _, err := c1.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expected c1 to be closed")
+	}
+}

--- a/server.go
+++ b/server.go
@@ -169,6 +169,5 @@ func handleConn(conn net.Conn, chains map[string]UserChain) {
 		return
 	}
 	debugLog.Printf("server responded with %v", resp)
-	go io.Copy(remote, conn)
-	io.Copy(conn, remote)
+	proxy(remote, conn)
 }


### PR DESCRIPTION
## Summary
- replace paired io.Copy calls with a helper that copies in both directions and closes peers on termination
- add tests ensuring connections close when either side ends

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a02d5c5a8483249ebfc0ec3663e900