### PR TITLE
Support context cancellation and dynamic proxy list for health checks

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"math/rand"
@@ -12,6 +13,8 @@ import (
 func main() {
 	flag.Parse()
 	rand.Seed(time.Now().UnixNano())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	cfg, err := loadConfig(*configPath)
 	if err != nil {
 		log.Fatal(err)
@@ -28,7 +31,7 @@ func main() {
 	for _, uc := range cfg.Chains {
 		userChains[uc.Username] = uc
 	}
-	startHealthChecks(&cfg)
+	startHealthChecks(ctx, &cfg)
 	startChainCacheCleanup(cfg.General.ChainCleanupInterval)
 	for {
 		c, err := ln.Accept()


### PR DESCRIPTION
## Summary
- allow cancelling health check goroutine with context.Context
- rebuild proxy list on each ticker tick
- propagate server context from main to health checks

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a02edb1b1c8324b69338f682693858