### PR TITLE
detect duplicate usernames

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -73,3 +73,13 @@ func TestLoadConfigInvalid(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestBuildUserChainsDuplicate(t *testing.T) {
+	chains := []UserChain{
+		{Username: "user1"},
+		{Username: "user1"},
+	}
+	if _, err := buildUserChains(chains); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,12 +3,24 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"strconv"
 	"time"
 )
+
+func buildUserChains(chains []UserChain) (map[string]UserChain, error) {
+	userChains := make(map[string]UserChain)
+	for _, uc := range chains {
+		if _, ok := userChains[uc.Username]; ok {
+			return nil, fmt.Errorf("duplicate username %q", uc.Username)
+		}
+		userChains[uc.Username] = uc
+	}
+	return userChains, nil
+}
 
 func main() {
 	flag.Parse()
@@ -27,9 +39,9 @@ func main() {
 		log.Fatal(err)
 	}
 	infoLog.Printf("listening on %s", addr)
-	userChains := make(map[string]UserChain)
-	for _, uc := range cfg.Chains {
-		userChains[uc.Username] = uc
+	userChains, err := buildUserChains(cfg.Chains)
+	if err != nil {
+		log.Fatal(err)
 	}
 	startHealthChecks(ctx, &cfg)
 	startChainCacheCleanup(cfg.General.ChainCleanupInterval)


### PR DESCRIPTION
## Summary
- add duplicate username detection when building user chains
- include test to ensure duplicates produce an error

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0316284b88324bf5753a068e88af4