### PR TITLE
Разрешить значение 0 для chain_cleanup_interval

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,6 @@ var configPath = flag.String("config", "config.yaml", "path to config file")
 
 const (
 	defaultHealthCheckInterval   = 30 * time.Second
-	defaultChainCleanupInterval  = 10 * time.Minute
 	defaultHealthCheckTimeout    = 5 * time.Second
 	defaultHealthCheckConcurrent = 10
 	proxyDialTimeout             = 5 * time.Second
@@ -83,9 +82,6 @@ func loadConfig(path string) (Config, error) {
 	if cfg.General.HealthCheckInterval == 0 {
 		cfg.General.HealthCheckInterval = defaultHealthCheckInterval
 	}
-	if cfg.General.ChainCleanupInterval == 0 {
-		cfg.General.ChainCleanupInterval = defaultChainCleanupInterval
-	}
 	if cfg.General.HealthCheckTimeout == 0 {
 		cfg.General.HealthCheckTimeout = defaultHealthCheckTimeout
 	}
@@ -108,8 +104,8 @@ func validateConfig(cfg *Config) error {
 	if cfg.General.HealthCheckInterval <= 0 {
 		return fmt.Errorf("general.health_check_interval must be positive")
 	}
-	if cfg.General.ChainCleanupInterval <= 0 {
-		return fmt.Errorf("general.chain_cleanup_interval must be positive")
+	if cfg.General.ChainCleanupInterval < 0 {
+		return fmt.Errorf("general.chain_cleanup_interval must be non-negative")
 	}
 	if cfg.General.HealthCheckTimeout <= 0 {
 		return fmt.Errorf("general.health_check_timeout must be positive")

--- a/config_test.go
+++ b/config_test.go
@@ -58,6 +58,17 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "negative cleanup interval",
+			cfg: Config{General: General{
+				Bind:                  "0.0.0.0",
+				Port:                  1080,
+				HealthCheckInterval:   time.Second,
+				ChainCleanupInterval:  -time.Second,
+				HealthCheckTimeout:    time.Second,
+				HealthCheckConcurrent: 1,
+			}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -68,9 +79,33 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
+func TestChainCleanupIntervalZero(t *testing.T) {
+	cfg := Config{General: General{
+		Bind:                  "127.0.0.1",
+		Port:                  1080,
+		HealthCheckInterval:   time.Second,
+		ChainCleanupInterval:  0,
+		HealthCheckTimeout:    time.Second,
+		HealthCheckConcurrent: 1,
+	}}
+	if err := validateConfig(&cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadConfigInvalid(t *testing.T) {
 	if _, err := loadConfig("testdata/invalid_config.yaml"); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestLoadConfigZeroCleanupInterval(t *testing.T) {
+	cfg, err := loadConfig("testdata/zero_cleanup_config.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.General.ChainCleanupInterval != 0 {
+		t.Fatalf("expected 0, got %v", cfg.General.ChainCleanupInterval)
 	}
 }
 

--- a/testdata/zero_cleanup_config.yaml
+++ b/testdata/zero_cleanup_config.yaml
@@ -1,0 +1,9 @@
+general:
+  bind: "0.0.0.0"
+  port: 1080
+  health_check_interval: 30s
+  chain_cleanup_interval: 0s
+  health_check_timeout: 5s
+  health_check_concurrency: 10
+
+chains: []


### PR DESCRIPTION
## Summary
- allow setting `chain_cleanup_interval` to 0 to disable cache cleanup
- cover zero and negative `chain_cleanup_interval` cases in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a03373e8988324bb3be98470a10557