### PR TITLE
Use strict YAML decoder

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,12 +65,15 @@ type Config struct {
 }
 
 func loadConfig(path string) (Config, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return Config{}, err
 	}
+	defer f.Close()
+	dec := yaml.NewDecoder(f)
+	dec.KnownFields(true)
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := dec.Decode(&cfg); err != nil {
 		return Config{}, err
 	}
 	if cfg.General.LogLevel == "" {

--- a/config_test.go
+++ b/config_test.go
@@ -99,6 +99,12 @@ func TestLoadConfigInvalid(t *testing.T) {
 	}
 }
 
+func TestLoadConfigUnknownField(t *testing.T) {
+	if _, err := loadConfig("testdata/unknown_field_config.yaml"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
 func TestLoadConfigZeroCleanupInterval(t *testing.T) {
 	cfg, err := loadConfig("testdata/zero_cleanup_config.yaml")
 	if err != nil {

--- a/testdata/unknown_field_config.yaml
+++ b/testdata/unknown_field_config.yaml
@@ -1,0 +1,10 @@
+general:
+  bind: "0.0.0.0"
+  port: 1080
+  health_check_interval: 30s
+  chain_cleanup_interval: 10m
+  health_check_timeout: 5s
+  health_check_concurrency: 10
+  extra_field: true
+
+chains: []


### PR DESCRIPTION
## Summary
- load configuration with a strict YAML decoder configured via `KnownFields(true)`
- add tests to ensure unknown fields cause failures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0371e9668832489b8ddb7ecf1158a