### PR TITLE
Add credential length checks for proxies and chains

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -201,6 +201,9 @@ func connectProxy(ctx context.Context, prev net.Conn, hop *Proxy, host string, p
 	if method == 0x02 {
 		u := []byte(hop.Username)
 		p := []byte(hop.Password)
+		if len(u) > 255 || len(p) > 255 {
+			return nil, fmt.Errorf("hop %s: username/password too long", hop.Name)
+		}
 		req := []byte{0x01, byte(len(u))}
 		req = append(req, u...)
 		req = append(req, byte(len(p)))

--- a/config.go
+++ b/config.go
@@ -117,6 +117,12 @@ func validateConfig(cfg *Config) error {
 		return fmt.Errorf("general.health_check_concurrency must be positive")
 	}
 	for ci, uc := range cfg.Chains {
+		if len(uc.Username) > 255 {
+			return fmt.Errorf("chains[%d]: username too long", ci)
+		}
+		if len(uc.Password) > 255 {
+			return fmt.Errorf("chains[%d]: password too long", ci)
+		}
 		for hi, hop := range uc.Chain {
 			if len(hop.Proxies) > 0 {
 				strat := strings.ToLower(hop.Strategy)
@@ -130,6 +136,12 @@ func validateConfig(cfg *Config) error {
 					if p.Port <= 0 || p.Port > 65535 {
 						return fmt.Errorf("chains[%d].chain[%d].proxies[%d]: port must be between 1 and 65535", ci, hi, pi)
 					}
+					if len(p.Username) > 255 {
+						return fmt.Errorf("chains[%d].chain[%d].proxies[%d]: username too long", ci, hi, pi)
+					}
+					if len(p.Password) > 255 {
+						return fmt.Errorf("chains[%d].chain[%d].proxies[%d]: password too long", ci, hi, pi)
+					}
 				}
 			} else {
 				if hop.Host == "" {
@@ -137,6 +149,12 @@ func validateConfig(cfg *Config) error {
 				}
 				if hop.Port <= 0 || hop.Port > 65535 {
 					return fmt.Errorf("chains[%d].chain[%d]: port must be between 1 and 65535", ci, hi)
+				}
+				if len(hop.Username) > 255 {
+					return fmt.Errorf("chains[%d].chain[%d]: username too long", ci, hi)
+				}
+				if len(hop.Password) > 255 {
+					return fmt.Errorf("chains[%d].chain[%d]: password too long", ci, hi)
 				}
 			}
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -68,6 +69,38 @@ func TestValidateConfig(t *testing.T) {
 				HealthCheckTimeout:    time.Second,
 				HealthCheckConcurrent: 1,
 			}},
+		},
+		{
+			name: "proxy username too long",
+			cfg: Config{
+				General: validGen,
+				Chains: []UserChain{
+					{
+						Chain: []*Hop{
+							{
+								Proxies: []*Proxy{{
+									Host:     "proxy.example",
+									Port:     1080,
+									Username: strings.Repeat("a", 256),
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "userchain password too long",
+			cfg: Config{
+				General: validGen,
+				Chains: []UserChain{
+					{
+						Username: "user",
+						Password: strings.Repeat("b", 256),
+						Chain:    []*Hop{{Host: "example.com", Port: 1080}},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- validate that proxy and user chain usernames/passwords are at most 255 bytes
- return error from connectProxy when credentials exceed 255 bytes
- add tests for overlong credentials

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a061c65acc83249397a9768663c12c