### PR TITLE
Add configurable I/O timeout and handshake deadlines

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ general:
   chain_cleanup_interval: 10m
   health_check_timeout: 5s
   health_check_concurrency: 10
+  io_timeout: 5s
 
 chains:
   - username: "user"

--- a/config_test.go
+++ b/config_test.go
@@ -14,6 +14,7 @@ func TestValidateConfig(t *testing.T) {
 		ChainCleanupInterval:  time.Second,
 		HealthCheckTimeout:    time.Second,
 		HealthCheckConcurrent: 1,
+		IOTimeout:             time.Second,
 	}
 	tests := []struct {
 		name string
@@ -28,6 +29,7 @@ func TestValidateConfig(t *testing.T) {
 				ChainCleanupInterval:  time.Second,
 				HealthCheckTimeout:    time.Second,
 				HealthCheckConcurrent: 1,
+				IOTimeout:             time.Second,
 			}},
 		},
 		{
@@ -68,6 +70,7 @@ func TestValidateConfig(t *testing.T) {
 				ChainCleanupInterval:  -time.Second,
 				HealthCheckTimeout:    time.Second,
 				HealthCheckConcurrent: 1,
+				IOTimeout:             time.Second,
 			}},
 		},
 		{
@@ -120,6 +123,7 @@ func TestChainCleanupIntervalZero(t *testing.T) {
 		ChainCleanupInterval:  0,
 		HealthCheckTimeout:    time.Second,
 		HealthCheckConcurrent: 1,
+		IOTimeout:             time.Second,
 	}}
 	if err := validateConfig(&cfg); err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- add `io_timeout` to configuration and propagate value
- set deadlines around SOCKS handshake I/O and clear afterward

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a065dfc5648324894338dd43147980