### PR TITLE
feat: reload chains from config

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type General struct {
 	HealthCheckTimeout    time.Duration `yaml:"health_check_timeout"`
 	HealthCheckConcurrent int           `yaml:"health_check_concurrency"`
 	IOTimeout             time.Duration `yaml:"io_timeout"`
+	ConfigReloadInterval  time.Duration `yaml:"config_reload_interval"`
 }
 
 type Proxy struct {
@@ -100,7 +101,6 @@ func loadConfig(path string) (Config, error) {
 	if err := validateConfig(&cfg); err != nil {
 		return Config{}, err
 	}
-	ioTimeout = cfg.General.IOTimeout
 	return cfg, nil
 }
 
@@ -116,6 +116,9 @@ func validateConfig(cfg *Config) error {
 	}
 	if cfg.General.ChainCleanupInterval < 0 {
 		return fmt.Errorf("general.chain_cleanup_interval must be non-negative")
+	}
+	if cfg.General.ConfigReloadInterval < 0 {
+		return fmt.Errorf("general.config_reload_interval must be non-negative")
 	}
 	if cfg.General.HealthCheckTimeout <= 0 {
 		return fmt.Errorf("general.health_check_timeout must be positive")

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ general:
   health_check_timeout: 5s
   health_check_concurrency: 10
   io_timeout: 5s
+  config_reload_interval: 0s
 
 chains:
   - username: "user"

--- a/health.go
+++ b/health.go
@@ -30,11 +30,13 @@ func startHealthChecks(ctx context.Context, cfg *Config) {
 			case <-ticker.C:
 			}
 			proxies := []*Proxy{}
+			chainsMu.RLock()
 			for i := range cfg.Chains {
 				for j := range cfg.Chains[i].Chain {
 					proxies = append(proxies, cfg.Chains[i].Chain[j].Proxies...)
 				}
 			}
+			chainsMu.RUnlock()
 			var wg sync.WaitGroup
 			sem := make(chan struct{}, cfg.General.HealthCheckConcurrent)
 			for _, p := range proxies {

--- a/reload.go
+++ b/reload.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	userChains atomic.Value
+	chainsMu   sync.RWMutex
+)
+
+func startConfigReload(ctx context.Context, cfg *Config) {
+	interval := cfg.General.ConfigReloadInterval
+	if interval <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			newCfg, err := loadConfig(*configPath)
+			if err != nil {
+				warnLog.Printf("config reload failed: %v", err)
+				continue
+			}
+			initProxies(&newCfg)
+			newChains, err := buildUserChains(newCfg.Chains)
+			if err != nil {
+				warnLog.Printf("config reload build chains: %v", err)
+				continue
+			}
+			chainCacheMu.Lock()
+			chainCache = make(map[string]*cachedChain)
+			chainCacheMu.Unlock()
+			chainsMu.Lock()
+			cfg.Chains = newCfg.Chains
+			userChains.Store(newChains)
+			chainsMu.Unlock()
+			infoLog.Printf("reloaded %d chains", len(newChains))
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- add config_reload_interval setting to periodically refresh proxy chains
- store user chain map atomically and reload chains without restarting
- guard health checks with RWMutex for safe dynamic updates

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a07d660010832482d1e97aa9df62cf