### PR TITLE
Add context-aware chain cache cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 	userChains.Store(ucMap)
 	startHealthChecks(ctx, &cfg)
-	startChainCacheCleanup(cfg.General.ChainCleanupInterval)
+	startChainCacheCleanup(ctx, cfg.General.ChainCleanupInterval)
 	startConfigReload(ctx, &cfg)
 	for {
 		c, err := ln.Accept()


### PR DESCRIPTION
## Summary
- allow chain cache cleanup to exit when context is cancelled
- pass the application context when launching cache cleanup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a32d6200988324aeea9d164bcb11b9