### PR TITLE
Add timeout to cleanupChain to avoid infinite ticker

### DIFF
--- a/reload.go
+++ b/reload.go
@@ -68,6 +68,8 @@ func startConfigReload(ctx context.Context, cfg *Config) {
 
 func cleanupChain(ctx context.Context, cs *ChainState) {
 	go func() {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 		for {
@@ -76,7 +78,8 @@ func cleanupChain(ctx context.Context, cs *ChainState) {
 				return
 			}
 			select {
-			case <-ctx.Done():
+			case <-timeoutCtx.Done():
+				warnLog.Printf("cleanup chain: timeout waiting for refs")
 				return
 			case <-ticker.C:
 			}


### PR DESCRIPTION
## Summary
- use context.WithTimeout in cleanupChain to limit wait and log when refs are held too long

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a343130f488324a5b1f931e0192983