### PR TITLE
test: add cache cleanup test

### DIFF
--- a/chain_cache_test.go
+++ b/chain_cache_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+    "context"
+    "testing"
+    "time"
+)
+
+func TestStartChainCacheCleanup(t *testing.T) {
+    ttl := 10 * time.Millisecond
+    cs := &ChainState{cache: &cachedChain{combo: []*Proxy{{}}, lastUsed: time.Now().Add(-2 * ttl)}}
+    userChains.Store(map[string]*ChainState{"u": cs})
+    defer userChains.Store(map[string]*ChainState{})
+
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+
+    startChainCacheCleanup(ctx, ttl)
+
+    // Wait until cache is cleared or timeout
+    for i := 0; i < 10; i++ {
+        cs.cacheMu.RLock()
+        cleared := cs.cache == nil
+        cs.cacheMu.RUnlock()
+        if cleared {
+            return
+        }
+        time.Sleep(ttl)
+    }
+    t.Fatal("cache was not cleaned")
+}
+


### PR DESCRIPTION
## Summary
- add unit test verifying chain cache cleanup after TTL expiry

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a3f83b366083248871e40f656bba96