### PR TITLE
Enable TCP no-delay on connections

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -180,6 +180,9 @@ func connectProxy(ctx context.Context, prev net.Conn, hop *Proxy, host string, p
 			}
 			return nil, err
 		}
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			tcp.SetNoDelay(true)
+		}
 	} else {
 		conn = prev
 	}

--- a/main.go
+++ b/main.go
@@ -84,6 +84,9 @@ func main() {
 			warnLog.Printf("accept: %v", err)
 			continue
 		}
+		if tcp, ok := c.(*net.TCPConn); ok {
+			tcp.SetNoDelay(true)
+		}
 		select {
 		case sem <- struct{}{}:
 			if ra, ok := c.RemoteAddr().(*net.TCPAddr); ok {

--- a/server.go
+++ b/server.go
@@ -10,6 +10,9 @@ import (
 
 func handleConn(conn net.Conn, chains map[string]*ChainState) {
 	defer conn.Close()
+	if tcp, ok := conn.(*net.TCPConn); ok {
+		tcp.SetNoDelay(true)
+	}
 	buf := make([]byte, 260)
 	conn.SetDeadline(time.Now().Add(ioTimeout))
 	if _, err := io.ReadFull(conn, buf[:2]); err != nil {
@@ -241,6 +244,9 @@ func handleConn(conn net.Conn, chains map[string]*ChainState) {
 			conn.Close()
 		}
 		return
+	}
+	if tcp, ok := remote.(*net.TCPConn); ok {
+		tcp.SetNoDelay(true)
 	}
 	defer remote.Close()
 	la := remote.LocalAddr().(*net.TCPAddr)


### PR DESCRIPTION
## Summary
- Disable Nagle's algorithm on accepted client connections
- Ensure both inbound and remote sockets use TCP no-delay during handling
- Apply TCP no-delay when dialing proxy hops in chains

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5410420148324bf9825fc4ed0d269